### PR TITLE
Modernize Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ java {
 
 tasks.register('buildOpenRocket', Exec) {
     workingDir 'openrocket'
-    def jarFile = file("build/libs/OpenRocket-${openRocketVersion}.jar")
+    def jarFile = file("openrocket/build/libs/OpenRocket-${openRocketVersion}.jar")
 
     commandLine gradleWrapper, 'build', '-x', 'test'
 

--- a/build.gradle
+++ b/build.gradle
@@ -52,11 +52,11 @@ tasks.register('buildOpenRocket', Exec) {
     workingDir 'openrocket'
     def jarFile = file("build/libs/OpenRocket-${openRocketVersion}.jar")
 
+    commandLine gradleWrapper, 'build', '-x', 'test'
+
     onlyIf {
         !jarFile.exists()
     }
-
-    commandLine gradleWrapper, 'build', '-x', 'test'
 }
 
 tasks.register('cleanOpenRocket', Exec) {

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/Main.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/Main.java
@@ -4,107 +4,24 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
 import info.openrocket.core.database.Databases;
-import info.openrocket.core.document.OpenRocketDocument;
-import info.openrocket.core.document.Simulation;
-import info.openrocket.core.file.GeneralRocketLoader;
-import info.openrocket.core.file.RocketLoadException;
-import info.openrocket.core.gui.util.SimpleFileFilter;
-import info.openrocket.core.logging.Markers;
 import info.openrocket.core.plugin.PluginModule;
 import info.openrocket.core.preferences.ApplicationPreferences;
-import info.openrocket.core.simulation.FlightDataType;
-import info.openrocket.core.simulation.FlightEvent;
-import info.openrocket.core.simulation.extension.SimulationExtension;
 import info.openrocket.core.startup.Application;
-import info.openrocket.swing.gui.main.BasicFrame;
-import info.openrocket.swing.gui.plot.SimulationPlotConfiguration;
-import info.openrocket.swing.gui.plot.SimulationPlotDialog;
-import info.openrocket.swing.gui.simulation.SimulationConfigDialog;
-import info.openrocket.swing.gui.simulation.SimulationRunDialog;
 import info.openrocket.swing.gui.theme.UITheme;
-import info.openrocket.swing.gui.util.FileHelper;
 import info.openrocket.swing.gui.util.GUIUtil;
-import info.openrocket.swing.gui.util.SwingPreferences;
 import info.openrocket.swing.startup.GuiModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.awt.Dialog;
-import java.awt.Frame;
-import java.awt.Window;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
-import java.io.File;
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import javax.swing.JButton;
-import javax.swing.JDialog;
-import javax.swing.JFileChooser;
-
 public class Main {
     private final static Logger log = LoggerFactory.getLogger(Main.class);
-
-    private static Frame frame = new Frame("Waterloo Rocketry Monte-Carlo Simulator");
 
     public static void main(String[] args) throws Exception {
 
         initializeOpenRocket();
+        SimulationOptionsFrame frame = new SimulationOptionsFrame();
+
         frame.setVisible(true);
-
-        OpenRocketDocument doc = configureDocument();
-
-        SimulationEngine simulationEngine = new SimulationEngine(doc);
-        Simulation[] sims = simulationEngine.getSimulations();
-
-        SimulationConfigDialog config = new SimulationConfigDialog(frame, doc, true, sims);
-        WindowAdapter closeConfigListener = new WindowAdapter() {
-            @Override
-            public void windowClosed(WindowEvent e) {
-                config.dispose();
-                frame.dispose();
-            }
-        };
-        config.addWindowListener(closeConfigListener);
-
-        Field okButtonField = config.getClass().getDeclaredField("okButton");
-        okButtonField.setAccessible(true);
-        JButton okButton = (JButton) okButtonField.get(config);
-
-        okButton.removeActionListener(okButton.getActionListeners()[0]); // remove default action
-        okButton.addActionListener(e -> {
-            log.info("Options accepted, start Monte Carlo Simulation");
-            for (int i = 1; i < sims.length; i++) {
-                sims[i].getSimulationExtensions().clear();
-                for (SimulationExtension ext : sims[0].getSimulationExtensions()) {
-                    sims[i].getSimulationExtensions().add(ext.clone());
-                }
-            }
-
-            config.removeWindowListener(closeConfigListener);
-            config.dispose();
-
-            // run simulations
-            JDialog runDialog = new SimulationRunDialog(frame, doc, sims);
-            runDialog.addWindowListener(new WindowAdapter() {
-                @Override
-                public void windowClosed(WindowEvent e) {
-                    log.info("Simulation done, processing data");
-                    List<SimulationData> data = simulationEngine.processSimulationData();
-                    if (data != null)
-                        displaySimulation(frame, data);
-                }
-            });
-        });
-
-        config.setVisible(true);
-
-//         run simulations
-//        new SimulationRunDialog(frame, doc, sims).setVisible(true);
-
 
     }
 
@@ -128,101 +45,6 @@ public class Main {
             prefs.setUITheme(UITheme.Themes.valueOf(cmdLAF));
         }
         GUIUtil.applyLAF();
-    }
-
-    /**
-     * Get the preferences of OpenRocket Swing
-     * @return Preferences object
-     */
-    private static SwingPreferences getOpenRocketPreferences() {
-        return (SwingPreferences) Application.getPreferences();
-    }
-
-    private static OpenRocketDocument configureDocument() throws RocketLoadException {
-        JFileChooser chooser = new JFileChooser();
-
-        chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-        chooser.setMultiSelectionEnabled(false);
-
-        // open OpenRocket file
-        chooser.addChoosableFileFilter(FileHelper.ALL_DESIGNS_FILTER);
-        chooser.addChoosableFileFilter(FileHelper.OPENROCKET_DESIGN_FILTER);
-        chooser.setFileFilter(FileHelper.OPENROCKET_DESIGN_FILTER);
-        chooser.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
-        int option = chooser.showOpenDialog(frame);
-        if (option != JFileChooser.APPROVE_OPTION) {
-            log.info(Markers.USER_MARKER, "Decided not to open files, option={}", option);
-            System.exit(0);
-        }
-
-        ((SwingPreferences) Application.getPreferences()).setDefaultDirectory(chooser.getCurrentDirectory());
-
-        File rocketFile = chooser.getSelectedFile();
-
-        log.info(Markers.USER_MARKER, "Opening rocket file {}", rocketFile);
-
-        // get thrust curve file
-        chooser.removeChoosableFileFilter(FileHelper.ALL_DESIGNS_FILTER);
-        chooser.removeChoosableFileFilter(FileHelper.OPENROCKET_DESIGN_FILTER);
-        chooser.setFileFilter(new SimpleFileFilter("Thrust Curve", false, ".rse"));
-
-        chooser.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
-        option = chooser.showOpenDialog(frame);
-        if (option != JFileChooser.APPROVE_OPTION) {
-            log.info(Markers.USER_MARKER, "Decided not to open files, option={}", option);
-            System.exit(0);
-        }
-
-        ((SwingPreferences) Application.getPreferences()).setDefaultDirectory(chooser.getCurrentDirectory());
-
-        File thrustCurveFile = chooser.getSelectedFile();
-
-        log.info(Markers.USER_MARKER, "Opening thrust curve file {}", thrustCurveFile);
-
-        OpenRocketDocument doc = new GeneralRocketLoader(rocketFile).load();
-
-        getOpenRocketPreferences().setUserThrustCurveFiles(Collections.singletonList(thrustCurveFile));
-
-        return doc;
-    }
-
-    /**
-     * Displays data of a simulation
-     */
-    private static void displaySimulation(Window parent, List<SimulationData> data) {
-        SimulationPlotConfiguration config = new SimulationPlotConfiguration("Low stability case");
-
-        config.addPlotDataType(FlightDataType.TYPE_ALTITUDE, 0);
-        config.addPlotDataType(FlightDataType.TYPE_VELOCITY_Z);
-        config.addPlotDataType(FlightDataType.TYPE_ACCELERATION_Z);
-        config.addPlotDataType(FlightDataType.TYPE_STABILITY);
-        config.addPlotDataType(FlightDataType.TYPE_CG_LOCATION);
-        config.addPlotDataType(FlightDataType.TYPE_CP_LOCATION);
-        config.setEvent(FlightEvent.Type.IGNITION, true);
-        config.setEvent(FlightEvent.Type.BURNOUT, true);
-        config.setEvent(FlightEvent.Type.APOGEE, true);
-        config.setEvent(FlightEvent.Type.RECOVERY_DEVICE_DEPLOYMENT, true);
-        config.setEvent(FlightEvent.Type.STAGE_SEPARATION, true);
-        config.setEvent(FlightEvent.Type.GROUND_HIT, true);
-        config.setEvent(FlightEvent.Type.TUMBLE, true);
-        config.setEvent(FlightEvent.Type.EXCEPTION, true);
-
-        final int[] plots = {data.size()};
-
-        for (Simulation simulation : data.stream().map(SimulationData::getSimulation).toList()) {
-            Dialog dialog = new Dialog(frame);
-            SimulationPlotDialog simDialog = SimulationPlotDialog.getPlot(dialog, simulation, config);
-            simDialog.setSize(1000, 500);
-            simDialog.setVisible(true);
-            dialog.addWindowListener(new WindowAdapter() {
-                @Override
-                public void windowClosing(WindowEvent e) {
-                    dialog.dispose();
-                    plots[0]--;
-                    if (plots[0] == 0) parent.dispose();
-                }
-            });
-        }
     }
 
 }

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationConditions.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationConditions.java
@@ -1,5 +1,6 @@
 package com.waterloorocketry.openrocket_monte_carlo;
 
+@Deprecated
 public class SimulationConditions {
     private final double windspeedMph;
     private final double windDirection;

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationData.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationData.java
@@ -15,23 +15,26 @@ import java.util.List;
 public class SimulationData {
     private final Simulation simulation;
     private final SimulationConditions simulationConditions;
-    private final double apogee;
-    private final double minStability;
-    private final double maxStability;
-    private final double apogeeStability;
-    private final double initStability;
-    private final double maxVelocity;
-    private final double maxMachNumber;
+    private double apogee;
+    private double minStability;
+    private double maxStability;
+    private double apogeeStability;
+    private double initStability;
+    private double maxVelocity;
+    private double maxMachNumber;
 
+    public SimulationData(Simulation simulation, SimulationConditions simulationConditions)  {
+        this.simulation = simulation;
+        this.simulationConditions = simulationConditions;
+    }
     /**
      * Construct a SimulationData object from OpenRocket data
      * @param simulation Simulation from OpenRocket
      */
-    public SimulationData(Simulation simulation, SimulationConditions simulationConditions) throws SimulationException {
-        this.simulation = simulation;
-        this.simulationConditions = simulationConditions;
-
+    public void processData() throws SimulationException {
         FlightData data = simulation.getSimulatedData();
+        if (data == null) throw new SimulationException("No simulation data recorded. Run a simulation first");
+
         apogee = data.getMaxAltitude();
         maxVelocity = data.getMaxVelocity();
         maxMachNumber = data.getMaxMachNumber();

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationData.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationData.java
@@ -14,7 +14,6 @@ import java.util.List;
  */
 public class SimulationData {
     private final Simulation simulation;
-    private final SimulationConditions simulationConditions;
     private double apogee;
     private double minStability;
     private double maxStability;
@@ -22,15 +21,12 @@ public class SimulationData {
     private double initStability;
     private double maxVelocity;
     private double maxMachNumber;
+    private boolean hasData = false;
 
-    public SimulationData(Simulation simulation, SimulationConditions simulationConditions)  {
+    public SimulationData(Simulation simulation)  {
         this.simulation = simulation;
-        this.simulationConditions = simulationConditions;
     }
-    /**
-     * Construct a SimulationData object from OpenRocket data
-     * @param simulation Simulation from OpenRocket
-     */
+
     public void processData() throws SimulationException {
         FlightData data = simulation.getSimulatedData();
         if (data == null) throw new SimulationException("No simulation data recorded. Run a simulation first");
@@ -75,6 +71,7 @@ public class SimulationData {
         this.initStability = initStability;
 
         apogeeStability = stability.get(apogeeIndex);
+        hasData = true;
     }
 
     /**
@@ -84,8 +81,8 @@ public class SimulationData {
         return simulation;
     }
 
-    public SimulationConditions getSimulationConditions() {
-        return simulationConditions;
+    public boolean hasData() {
+        return simulation.hasSimulationData() && hasData;
     }
 
     public double getApogee() {

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationEngine.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationEngine.java
@@ -7,6 +7,7 @@ import info.openrocket.core.simulation.SimulationOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.beans.PropertyChangeSupport;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -31,6 +32,7 @@ public class SimulationEngine {
         this.simulationCount = simulationCount;
         for (int i = 0; i < simulationCount; i++) {
             Simulation sim = new Simulation(doc, doc.getRocket());
+            sim.setName("Simulation " + i);
             SimulationConditions simulationConditions = configureSimulationOptions(sim.getOptions());
             data.add(new SimulationData(sim, simulationConditions));
         }
@@ -41,7 +43,6 @@ public class SimulationEngine {
     }
 
     public List<SimulationData> processSimulationData() {
-        // TODO: name each simulation
         for (SimulationData d : data) {
             try {
                 d.processData();
@@ -126,5 +127,4 @@ public class SimulationEngine {
     private static double randomGauss(Random random, double mu, double sigma) {
         return random.nextGaussian() * sigma + mu;
     }
-
 }

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationEngine.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationEngine.java
@@ -1,20 +1,12 @@
 package com.waterloorocketry.openrocket_monte_carlo;
 
-import com.github.weisj.jsvg.nodes.Marker;
 import info.openrocket.core.document.OpenRocketDocument;
 import info.openrocket.core.document.Simulation;
 import info.openrocket.core.simulation.exception.SimulationException;
-import info.openrocket.swing.gui.plot.SimulationPlotConfiguration;
-import info.openrocket.swing.gui.plot.SimulationPlotDialog;
-import info.openrocket.core.simulation.FlightDataType;
-import info.openrocket.core.simulation.FlightEvent;
 import info.openrocket.core.simulation.SimulationOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.awt.*;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -29,14 +21,15 @@ public class SimulationEngine {
     /**
      * How many simulations we should run
      */
-    private static final int SIMULATION_COUNT = 5;
+    private final int simulationCount;
 
     private static final double FEET_METRES = 3.28084;
 
-    private List<SimulationData> data = new ArrayList<>();
+    private final List<SimulationData> data = new ArrayList<>();
 
-    SimulationEngine(OpenRocketDocument doc) {
-        for (int i = 0; i < SIMULATION_COUNT; i++) {
+    SimulationEngine(OpenRocketDocument doc, int simulationCount) {
+        this.simulationCount = simulationCount;
+        for (int i = 0; i < simulationCount; i++) {
             Simulation sim = new Simulation(doc, doc.getRocket());
             SimulationConditions simulationConditions = configureSimulationOptions(sim.getOptions());
             data.add(new SimulationData(sim, simulationConditions));
@@ -71,7 +64,7 @@ public class SimulationEngine {
         Statistics.Sample maxMach = Statistics.calculateSample(
                 data.stream().map(SimulationData::getMaxMachNumber).collect(Collectors.toList()));
 
-        log.info("Data over " + SIMULATION_COUNT + " runs:");
+        log.info("Data over " + simulationCount + " runs:");
         log.info("Apogee (ft): {}", apogee);
         log.info("Max mach number: {}", maxMach);
         log.info("Min stability: {}", minStability);

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationEngine.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationEngine.java
@@ -1,0 +1,137 @@
+package com.waterloorocketry.openrocket_monte_carlo;
+
+import com.github.weisj.jsvg.nodes.Marker;
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.Simulation;
+import info.openrocket.core.simulation.exception.SimulationException;
+import info.openrocket.swing.gui.plot.SimulationPlotConfiguration;
+import info.openrocket.swing.gui.plot.SimulationPlotDialog;
+import info.openrocket.core.simulation.FlightDataType;
+import info.openrocket.core.simulation.FlightEvent;
+import info.openrocket.core.simulation.SimulationOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.*;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+/**
+ * The main class that is run
+ */
+public class SimulationEngine {
+    private final static Logger log = LoggerFactory.getLogger(SimulationEngine.class);
+    /**
+     * How many simulations we should run
+     */
+    private static final int SIMULATION_COUNT = 5;
+
+    private static final double FEET_METRES = 3.28084;
+
+    private List<SimulationData> data = new ArrayList<>();
+
+    SimulationEngine(OpenRocketDocument doc) {
+        for (int i = 0; i < SIMULATION_COUNT; i++) {
+            Simulation sim = new Simulation(doc, doc.getRocket());
+            SimulationConditions simulationConditions = configureSimulationOptions(sim.getOptions());
+            data.add(new SimulationData(sim, simulationConditions));
+        }
+    }
+
+    public Simulation[] getSimulations() {
+        return data.stream().map(SimulationData::getSimulation).toArray(Simulation[]::new);
+    }
+
+    public List<SimulationData> processSimulationData() {
+        // TODO: name each simulation
+        for (SimulationData d : data) {
+            try {
+                d.processData();
+            } catch (SimulationException e) {
+                log.error(e.getMessage());
+                return null;
+            }
+        }
+
+        Statistics.Sample apogee = Statistics.calculateSample(
+                data.stream().map(SimulationData::getApogee).map((v) -> v * FEET_METRES).collect(Collectors.toList()));
+        double minStability = data.stream().mapToDouble(SimulationData::getMinStability).min().getAsDouble();
+        double maxStability = data.stream().mapToDouble(SimulationData::getMaxStability).max().getAsDouble();
+        Statistics.Sample initStability = Statistics.calculateSample(
+                data.stream().map(SimulationData::getInitStability).collect(Collectors.toList()));
+        double lowInitStabilityPercentage = (double) data.stream().mapToDouble(SimulationData::getInitStability)
+                .filter((stability) -> stability < 1.5).count() / data.size();
+        Statistics.Sample apogeeStability = Statistics.calculateSample(
+                data.stream().map(SimulationData::getApogeeStability).collect(Collectors.toList()));
+        Statistics.Sample maxMach = Statistics.calculateSample(
+                data.stream().map(SimulationData::getMaxMachNumber).collect(Collectors.toList()));
+
+        log.info("Data over " + SIMULATION_COUNT + " runs:");
+        log.info("Apogee (ft): {}", apogee);
+        log.info("Max mach number: {}", maxMach);
+        log.info("Min stability: {}", minStability);
+        log.info("Max stability: {}", maxStability);
+        log.info("Apogee stability: {}", apogeeStability);
+        log.info("Initial stability: {}", initStability);
+        log.info("Percentage of initial stability less than 1.5: {}", lowInitStabilityPercentage);
+
+        return data.stream().sorted(Comparator.comparing(SimulationData::getMinStability))
+                .limit(5).toList();
+    }
+
+    /**
+     * Set the options for the flight simulation
+     * @param opts The options object
+     */
+    private static SimulationConditions configureSimulationOptions(SimulationOptions opts) {
+        Random random = new Random();
+
+        // Units are in m/s so conversion needed
+
+        opts.setLaunchRodLength(260 * 2.54 / 100); // 260 inches (to cm) to m
+        opts.setLaunchRodAngle(Math.toRadians(5)); // 5 +- 1 deg in Launch Angle
+
+        double windSpeed = randomGauss(random, 8.449, 4.45);
+        opts.getAverageWindModel().setAverage(windSpeed * 0.44707);  // 8.449 mph
+        log.info("Cond: Avg WindSpeed: {}mph", windSpeed);
+        opts.getAverageWindModel().setStandardDeviation(0.8449 * 0.44707);  // 4.450 mph Std.Dev of wind
+        opts.getAverageWindModel().setTurbulenceIntensity(0.5);  // 10%
+        double windDirection = randomGauss(random, 90, 30);
+        opts.getAverageWindModel().setDirection(Math.toRadians(windDirection)); // 90+-30 deg
+        log.info("Cond: windDirection: {}degrees", windDirection);
+        opts.setLaunchIntoWind(true);  // 90+-30 deg
+        log.info("Cond: Launch Into Wind");
+
+        opts.setLaunchLongitude(-109); // -109E
+        opts.setLaunchLatitude(32.9); // 32.9N
+        opts.setLaunchAltitude(4848*0.3048); // 4848 ft
+
+        opts.setISAAtmosphere(false);
+
+        double temperature = randomGauss(random, 31.22, 10.51 * 5 / 9);
+        opts.setLaunchTemperature(temperature + 273.15);  // 31.22 +- 1 Celcius (88.2 F) in Temperature
+        log.info("Cond: Temperature: {}" + 32 + "F", temperature / 5 * 9);
+
+        double pressure = randomGauss(random, 1008, 3.938);
+        opts.setLaunchPressure(pressure * 100);  // 1008 mbar +- 1 in Pressure
+        log.info("Cond: Pressure: {}mbar", pressure);
+
+        return new SimulationConditions(windSpeed, windDirection, temperature / 5 * 9 + 32, pressure);
+    }
+
+    /**
+     * Choose a random number from a Gaussian distribution with a given mean and standard deviation
+     * @param random Random number generator
+     * @param mu Mean
+     * @param sigma Standard deviation
+     */
+    private static double randomGauss(Random random, double mu, double sigma) {
+        return random.nextGaussian() * sigma + mu;
+    }
+
+}

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationOptionsFrame.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationOptionsFrame.java
@@ -1,0 +1,322 @@
+package com.waterloorocketry.openrocket_monte_carlo;
+
+import info.openrocket.core.document.OpenRocketDocument;
+import info.openrocket.core.document.Simulation;
+import info.openrocket.core.file.GeneralRocketLoader;
+import info.openrocket.core.file.RocketLoadException;
+import info.openrocket.core.gui.util.SimpleFileFilter;
+import info.openrocket.core.logging.Markers;
+import info.openrocket.core.simulation.FlightDataType;
+import info.openrocket.core.simulation.FlightEvent;
+import info.openrocket.core.simulation.extension.SimulationExtension;
+import info.openrocket.core.startup.Application;
+import info.openrocket.swing.gui.plot.SimulationPlotConfiguration;
+import info.openrocket.swing.gui.plot.SimulationPlotDialog;
+import info.openrocket.swing.gui.simulation.SimulationConfigDialog;
+import info.openrocket.swing.gui.simulation.SimulationRunDialog;
+import info.openrocket.swing.gui.theme.UITheme;
+import info.openrocket.swing.gui.util.FileHelper;
+import info.openrocket.swing.gui.util.SwingPreferences;
+import net.miginfocom.swing.MigLayout;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.BorderLayout;
+import java.awt.Dialog;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.beans.PropertyChangeSupport;
+import java.io.File;
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.List;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFileChooser;
+import javax.swing.JFormattedTextField;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+
+public class SimulationOptionsFrame extends JFrame {
+    private final static Logger log = LoggerFactory.getLogger(SimulationOptionsFrame.class);
+
+    private final PropertyChangeSupport pcs = new PropertyChangeSupport(this);
+    private final String
+            THRUST_FILE_SET_EVENT = "thrustFileSet",
+            ROCKET_FILE_SET_EVENT = "rocketFileSet",
+            SIMULATIONS_CONFIGURED_EVENT = "simulationConfigured";
+
+    private OpenRocketDocument document;
+
+    private File openRocketFile, thrustCurveFile;
+
+    private int numSimulations = 100;
+
+    private SimulationEngine simulationEngine;
+
+    static {
+        initColors();
+    }
+
+    void setThrustCurveFile(File thrustCurveFile) {
+        pcs.firePropertyChange(THRUST_FILE_SET_EVENT, this.thrustCurveFile, thrustCurveFile);
+        this.thrustCurveFile = thrustCurveFile;
+    }
+
+    void setOpenRocketFile(File openRocketFile) {
+        pcs.firePropertyChange(ROCKET_FILE_SET_EVENT, this.openRocketFile, openRocketFile);
+        this.openRocketFile = openRocketFile;
+    }
+
+    private void setSimulationEngine(SimulationEngine simulationEngine) {
+        pcs.firePropertyChange(SIMULATIONS_CONFIGURED_EVENT, this.simulationEngine, simulationEngine);
+        this.simulationEngine = simulationEngine;
+    }
+
+    public SimulationOptionsFrame() {
+        super("Waterloo Rocketry Monte-Carlo Simulator");
+        this.setSize(800, 600);
+        this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+
+        final JPanel contentPanel = new JPanel(new MigLayout("fill, insets 0, wrap 1"));
+
+        contentPanel.add(addTopPanel(), "grow, push");
+        contentPanel.add(addBottomPanel(), "dock south");
+
+        this.add(contentPanel, BorderLayout.CENTER);
+    }
+
+    private JPanel addTopPanel() {
+        JPanel topPanel = new JPanel(new MigLayout("fill, wrap 2", "[grow 0]para[grow]"));
+
+        topPanel.add(new JLabel("Thrust Curve File"), "align label, growx");
+        final JPanel thrustCurveFileSelectButton = getThrustCurveFileSelectPanel();
+        topPanel.add(thrustCurveFileSelectButton, "align right");
+
+        topPanel.add(new JLabel("Rocket File"), "align label, growx");
+        final JPanel rocketFileSelectButton = getRocketFileSelectPanel();
+        topPanel.add(rocketFileSelectButton, "align right");
+
+        topPanel.add(new JLabel("Number of simulations"), "align label");
+        final JFormattedTextField numSimTextField = getNumSimField();
+        topPanel.add(numSimTextField, "growx");
+
+        final JButton configButton = getConfigButton();
+        topPanel.add(configButton, "span, growx");
+
+        return topPanel;
+    }
+
+    private JFormattedTextField getNumSimField() {
+        final JFormattedTextField numSimTextField = new JFormattedTextField(numSimulations);
+        numSimTextField.addPropertyChangeListener("value",
+                evt -> {
+                    numSimulations = Integer.parseInt(numSimTextField.getText());
+                    pcs.firePropertyChange(SIMULATIONS_CONFIGURED_EVENT, this.simulationEngine, null);
+                    this.simulationEngine = null; // invalidate outdated simulations
+                });
+
+        return numSimTextField;
+    }
+
+    private JPanel addBottomPanel() {
+        final JPanel bottomPanel = new JPanel(new MigLayout("fill, insets 20"));
+
+        final JButton closeButton = new JButton("Close");
+        closeButton.addActionListener(e -> dispose());
+        bottomPanel.add(closeButton, "split 2, tag ok");
+
+        final JButton runButton = getRunButton();
+        bottomPanel.add(runButton, "tag ok");
+
+        return bottomPanel;
+    }
+
+
+    private @NotNull JPanel getThrustCurveFileSelectPanel() {
+        JPanel thrustCurveFileSelectPanel = new JPanel(new MigLayout("fill, wrap 2, ins 0"));
+
+        final JLabel thrustCurveFilePath = new JLabel();
+        final JButton thrustCurveFileSelectButton = new JButton("Select File");
+        thrustCurveFileSelectButton.addActionListener(e -> {
+            JFileChooser chooser = new JFileChooser();
+            chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+            chooser.setMultiSelectionEnabled(false);
+            // open thrust curve file
+            chooser.setFileFilter(new SimpleFileFilter("Thrust Curve", false, ".rse"));
+            chooser.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
+            int option = chooser.showOpenDialog(this);
+            if (option != JFileChooser.APPROVE_OPTION) {
+                log.info(Markers.USER_MARKER, "Decided not to open thrust curve file, option={}", option);
+                return;
+            }
+            ((SwingPreferences) Application.getPreferences()).setDefaultDirectory(chooser.getCurrentDirectory());
+
+            setThrustCurveFile(chooser.getSelectedFile());
+            log.info(Markers.USER_MARKER, "Opening thrust curve file {}", thrustCurveFile);
+
+            // invalidate previous rocket file with updated thrust curves
+            setOpenRocketFile(openRocketFile);
+
+            thrustCurveFilePath.setText(thrustCurveFile.getName());
+
+            Application.getPreferences().setUserThrustCurveFiles(Collections.singletonList(thrustCurveFile));
+        });
+
+        thrustCurveFileSelectPanel.add(thrustCurveFilePath, "growx, align right");
+        thrustCurveFileSelectPanel.add(thrustCurveFileSelectButton, "align right");
+        return thrustCurveFileSelectPanel;
+    }
+
+    private @NotNull JPanel getRocketFileSelectPanel() {
+        JPanel rocketFileSelectPanel = new JPanel(new MigLayout("fill, wrap 2, ins 0"));
+
+        final JLabel rocketFilePath = new JLabel();
+        final JButton rocketFileSelectButton = new JButton("Select File");
+        rocketFileSelectButton.addActionListener(e -> {
+            JFileChooser chooser = new JFileChooser();
+
+            chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
+            chooser.setMultiSelectionEnabled(false);
+            // open OpenRocket file
+            chooser.addChoosableFileFilter(FileHelper.ALL_DESIGNS_FILTER);
+            chooser.addChoosableFileFilter(FileHelper.OPENROCKET_DESIGN_FILTER);
+            chooser.setFileFilter(FileHelper.OPENROCKET_DESIGN_FILTER);
+            chooser.setCurrentDirectory(((SwingPreferences) Application.getPreferences()).getDefaultDirectory());
+            int option = chooser.showOpenDialog(this);
+            if (option != JFileChooser.APPROVE_OPTION) {
+                log.info(Markers.USER_MARKER, "Decided not to open rocket file, option={}", option);
+                return;
+            }
+
+            ((SwingPreferences) Application.getPreferences()).setDefaultDirectory(chooser.getCurrentDirectory());
+
+            log.info(Markers.USER_MARKER, "Opening rocket file {}", openRocketFile);
+            setOpenRocketFile(chooser.getSelectedFile());
+
+            rocketFilePath.setText(openRocketFile.getName());
+
+            try {
+                document = new GeneralRocketLoader(openRocketFile).load();
+            } catch (RocketLoadException ex) {
+                log.error(Markers.USER_MARKER, "Error loading Rocket Document", ex);
+            }
+        });
+        rocketFileSelectButton.setEnabled(false);
+        pcs.addPropertyChangeListener(THRUST_FILE_SET_EVENT, event ->
+                rocketFileSelectButton.setEnabled(event.getNewValue() != null));
+
+        rocketFileSelectPanel.add(rocketFilePath, "growx, align right");
+        rocketFileSelectPanel.add(rocketFileSelectButton, "align right");
+        return rocketFileSelectPanel;
+    }
+
+    private @NotNull JButton getConfigButton() {
+        final JButton configButton = new JButton("Set simulation options");
+        configButton.addActionListener( e -> {
+            setSimulationEngine(new SimulationEngine(document, numSimulations));
+            Simulation[] sims = simulationEngine.getSimulations();
+            SimulationConfigDialog config = new SimulationConfigDialog(this, document, true, sims);
+            WindowAdapter closeConfigListener = new WindowAdapter() {
+                @Override
+                public void windowClosed(WindowEvent e) {
+                    config.dispose();
+                }
+            };
+            config.addWindowListener(closeConfigListener);
+
+            try {
+                Field okButtonField = config.getClass().getDeclaredField("okButton");
+                okButtonField.setAccessible(true);
+                JButton okButton = (JButton) okButtonField.get(config);
+
+                okButton.removeActionListener(okButton.getActionListeners()[0]); // remove default action
+                okButton.addActionListener(event -> config.dispose());
+            } catch (Exception exception) {
+                log.error("Failed to update simulation options ok button", exception);
+            }
+
+            config.setVisible(true);
+        });
+        configButton.setEnabled(false);
+        pcs.addPropertyChangeListener(ROCKET_FILE_SET_EVENT, event ->
+                configButton.setEnabled(event.getNewValue() != null));
+        return configButton;
+    }
+
+    private @NotNull JButton getRunButton() {
+        final JButton runButton = new JButton("Run");
+        runButton.addActionListener(e -> {
+
+            Simulation[] sims = simulationEngine.getSimulations();
+            log.info("Options accepted, starting Monte Carlo Simulation");
+            for (int i = 1; i < sims.length; i++) {
+                sims[i].getSimulationExtensions().clear();
+                for (SimulationExtension ext : sims[0].getSimulationExtensions()) {
+                    sims[i].getSimulationExtensions().add(ext.clone());
+                }
+            }
+
+            // run simulations
+            JDialog runDialog = new SimulationRunDialog(this, document, sims);
+            runDialog.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosed(WindowEvent e) {
+                    log.info("Simulation done, processing data");
+                    List<SimulationData> data = simulationEngine.processSimulationData();
+                    if (data != null)
+                        displaySimulation(data);
+                }
+            });
+            runDialog.setVisible(true);
+        });
+        runButton.setEnabled(false);
+        pcs.addPropertyChangeListener(SIMULATIONS_CONFIGURED_EVENT, event ->
+                runButton.setEnabled(event.getNewValue() != null));
+        return runButton;
+    }
+
+    /**
+     * Displays data of a simulation
+     */
+    private void displaySimulation(List<SimulationData> data) {
+        SimulationPlotConfiguration config = new SimulationPlotConfiguration("Low stability case");
+
+        config.addPlotDataType(FlightDataType.TYPE_ALTITUDE, 0);
+        config.addPlotDataType(FlightDataType.TYPE_VELOCITY_Z);
+        config.addPlotDataType(FlightDataType.TYPE_ACCELERATION_Z);
+        config.addPlotDataType(FlightDataType.TYPE_STABILITY);
+        config.addPlotDataType(FlightDataType.TYPE_CG_LOCATION);
+        config.addPlotDataType(FlightDataType.TYPE_CP_LOCATION);
+        config.setEvent(FlightEvent.Type.IGNITION, true);
+        config.setEvent(FlightEvent.Type.BURNOUT, true);
+        config.setEvent(FlightEvent.Type.APOGEE, true);
+        config.setEvent(FlightEvent.Type.RECOVERY_DEVICE_DEPLOYMENT, true);
+        config.setEvent(FlightEvent.Type.STAGE_SEPARATION, true);
+        config.setEvent(FlightEvent.Type.GROUND_HIT, true);
+        config.setEvent(FlightEvent.Type.TUMBLE, true);
+        config.setEvent(FlightEvent.Type.EXCEPTION, true);
+
+        for (Simulation simulation : data.stream().map(SimulationData::getSimulation).toList()) {
+            Dialog dialog = new Dialog(this);
+            SimulationPlotDialog simDialog = SimulationPlotDialog.getPlot(dialog, simulation, config);
+            simDialog.setSize(1000, 500);
+            simDialog.setVisible(true);
+            dialog.addWindowListener(new WindowAdapter() {
+                @Override
+                public void windowClosing(WindowEvent e) {
+                    dialog.dispose();
+                }
+            });
+        }
+    }
+
+    private static void initColors() {
+//        textColor = GUIUtil.getUITheme().getTextColor();
+//        dimTextColor = GUIUtil.getUITheme().getDimTextColor();
+        UITheme.Theme.addUIThemeChangeListener(SimulationConfigDialog::updateColors);
+    }
+
+}

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationOptionsFrame.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationOptionsFrame.java
@@ -368,7 +368,7 @@ public class SimulationOptionsFrame extends JFrame {
 
 
             try {
-                setSimulationEngine(new SimulationEngine(document,  chooser.getSelectedFile()));
+                setSimulationEngine(new SimulationEngine(document, chooser.getSelectedFile()));
             } catch (Exception e) {
                 log.error("Failed to import CSV data", e);
 


### PR DESCRIPTION
This PR refactors the existing plugin to incorporate OR's existing components. This wastes less time implementing existing functions and allows for future OR features to be automatically included (bar any major API changes).

Create a simple UI in SimulationOptionsDialog to configure simulations and select required rocket/thrust curve files.
Most components should reuse OR's existing components. Mainly the SimulationConfigDialog which has a lot of simulation options that we already require but is implemented in vanilla OR (extension support, import CSV, etc..)

Move monte-carlo simulation logic to new SimulationEngine class.
Remove custom simulation threading logic - OR already handles this via SimulationRunDialog

This PR now implements the new multi windlevel model. Try it by changing the wind level when setting the simulation options.
CSV data import also added

Reviewers:
- Test the UI
- Test if previous functionality is unchanged for the most part
- Add multiple wind levels and test if simulation runs correctly
- Import CSV data and test if valid file formats are accepted and simulation runs correctly

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/or-monte-carlo/8)
<!-- Reviewable:end -->
![image](https://github.com/user-attachments/assets/401e9585-45b4-4c9f-aafd-b269e7478d92)

