### PR TITLE
fix generated sim options being overriden, extension support

### DIFF
--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationEngine.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationEngine.java
@@ -4,6 +4,7 @@ import com.opencsv.CSVParser;
 import info.openrocket.core.document.OpenRocketDocument;
 import info.openrocket.core.document.Simulation;
 import info.openrocket.core.models.wind.MultiLevelPinkNoiseWindModel;
+import info.openrocket.core.models.wind.WindModelType;
 import info.openrocket.core.simulation.SimulationOptions;
 import info.openrocket.core.simulation.exception.SimulationException;
 import info.openrocket.core.unit.Unit;
@@ -201,13 +202,14 @@ public class SimulationEngine {
     private void configureSimulationOptions(SimulationOptions opts) {
         Random random = new Random();
 
+        opts.setWindModelType(WindModelType.MULTI_LEVEL);
         for (MultiLevelPinkNoiseWindModel.LevelWindModel windLevel : opts.getMultiLevelWindModel().getLevels()) {
             double windSpeed = randomGauss(random, windLevel.getSpeed(), windLevel.getStandardDeviation());
             windLevel.setSpeed(windSpeed);
             log.debug("Cond @ {}: Avg WindSpeed: {}mph", windLevel.getAltitude(), windSpeed);
 
             double windDirection = randomGauss(random, windLevel.getDirection(), windDirStdDev);
-            opts.getAverageWindModel().setDirection(Math.toRadians(windDirection));
+            windLevel.setDirection(Math.toRadians(windDirection));
             log.debug("Cond @ {}: windDirection: {}degrees", windLevel.getAltitude(), windDirection);
         }
 

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationOptionsFrame.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationOptionsFrame.java
@@ -35,7 +35,8 @@ import java.awt.BorderLayout;
 import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.beans.PropertyChangeListener;
@@ -400,14 +401,19 @@ public class SimulationOptionsFrame extends JFrame {
                 okButtonField.setAccessible(true);
                 JButton okButton = (JButton) okButtonField.get(config);
 
-                okButton.removeActionListener(okButton.getActionListeners()[0]); // remove default action
+                // remove all current listeners
+                for (ActionListener listener : okButton.getActionListeners())
+                    okButton.removeActionListener(listener);
+                for (WindowListener listener : config.getWindowListeners())
+                    config.removeWindowListener(listener);
+
                 okButton.addActionListener(event -> {
                         log.info(Markers.USER_MARKER, "Simulation options accepted, creating simulations...");
-                        for(Simulation s : sims) { // copy simulation extensions
-                            s.getSimulationExtensions().clear();
+                        for(int i = 1; i < sims.length; i++) { // copy simulation extensions
+                            sims[i].getSimulationExtensions().clear();
 
                             for(SimulationExtension c : sims[0].getSimulationExtensions()) {
-                                s.getSimulationExtensions().add(c.clone());
+                                sims[i].getSimulationExtensions().add(c.clone());
                             }
                         }
                         simulationEngine.generateMonteCarloSimulationConditions();


### PR DESCRIPTION
Simulation options were being overridden by OpenRocket event listeners - removed. (This caused all simulations to have the same starting conditions, i dont' know why i didn't see this)
Fixed extension copying 