### PR TITLE
add wind level exports

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.waterloorocketry'
-version '1.4.0'
+version '1.5.0'
 
 ext {
     openRocketVersion = '24.12'

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/Listener.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/Listener.java
@@ -1,0 +1,5 @@
+package com.waterloorocketry.openrocket_monte_carlo;
+
+public interface Listener {
+    void update();
+}

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationOptionsFrame.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationOptionsFrame.java
@@ -292,10 +292,7 @@ public class SimulationOptionsFrame extends JFrame {
             try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(file))) {
                 for (int idx : selectedIdx) {
                     SimulationData data = tableModel.getDataAt(idx);
-                    if (!data.hasData()) {
-                        log.warn("No data for simulation {}, skipping export", data.getName());
-                        continue;
-                    }
+                    
                     log.debug("Exporting simulation data for {}", data.getName());
 
                     ZipEntry entry = new ZipEntry(data.getName() + ".csv");

--- a/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationTableModel.java
+++ b/or-monte-carlo/src/com/waterloorocketry/openrocket_monte_carlo/SimulationTableModel.java
@@ -1,0 +1,80 @@
+package com.waterloorocketry.openrocket_monte_carlo;
+
+import javax.swing.table.AbstractTableModel;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SimulationTableModel extends AbstractTableModel implements Listener {
+    private final List<SimulationData> data = new ArrayList<>();
+    private final String[] columnNames =
+            {"Simulation Name", "Wind Speed(mph)", "Wind Direction(°)", "Temperature(°C)", "Pressure(mbar)",
+                    "Apogee(ft)", "Max Velocity(m/s)", "Min Stability"};
+
+    public void addSimulation(SimulationData simulation) {
+        simulation.addListener(this);
+        data.add(simulation);
+        fireTableDataChanged();
+    }
+
+    public void addSimulations(List<SimulationData> simulations) {
+        for (SimulationData simulation : simulations) {
+            addSimulation(simulation);
+        }
+    }
+
+    public void clearSimulations() {
+        data.clear();
+        fireTableDataChanged();
+    }
+
+    @Override
+    public String getColumnName(int column) {
+        return columnNames[column];
+    }
+
+    @Override
+    public int getRowCount() {
+        return data.size();
+    }
+
+    @Override
+    public int getColumnCount() {
+        return columnNames.length;
+    }
+
+    @Override
+    public Object getValueAt(int rowIndex, int columnIndex) {
+        switch (columnIndex) {
+            case 0:
+                return data.get(rowIndex).getName();
+            case 1:
+                return data.get(rowIndex).getMaxWindSpeedInMPH();
+            case 2:
+                return data.get(rowIndex).getMaxWindDirectionInDegrees();
+            case 3:
+                return data.get(rowIndex).getTemperatureInCelsius();
+            case 4:
+                return data.get(rowIndex).getPressureInMBar();
+            case 5:
+                return data.get(rowIndex).getApogeeInFeet();
+            case 6:
+                return data.get(rowIndex).getMaxVelocity();
+            case 7:
+                if (data.get(rowIndex).getMinStability().isEmpty()) {
+                    return null;
+                }
+                return data.get(rowIndex).getMinStability().get(0);
+            default:
+                return null;
+        }
+    }
+
+    public SimulationData getDataAt(int rowIndex) {
+        return data.get(rowIndex);
+    }
+
+    @Override
+    public void update() {
+        fireTableDataChanged();
+    }
+}


### PR DESCRIPTION
This pull request introduces new functionality for exporting wind level data from simulations, improves the simulation list table with a custom table model, and implements a listener pattern for better UI updates. The changes enhance both the usability and maintainability of the simulation data handling and display.

**Export wind level data:**

* Added an "Export Wind Levels" button to the simulation list panel in `SimulationOptionsFrame`, allowing users to export wind level data for selected simulations as CSV files inside a ZIP archive. The export handles file overwrites and only includes simulations with available data.

* Exported data follows OpenRocket format `altitude(ft),speed(mph),direction(deg),stddev(mph),windDirStdDev(deg)`. The units are not included in the header per OpenRocket's format but for clarity.

* Implemented the `exportWindLevels()` method in `SimulationData` to generate CSV-formatted wind level data for export.

**Simulation table improvements:**

* Introduced a new `SimulationTableModel` class that extends `AbstractTableModel` and implements the new `Listener` interface, replacing the previous generic table model. This model automatically updates the table when simulation data changes and simplifies adding and clearing simulations. [[1]](diffhunk://#diff-a751ddd5d27f93d1f53b07e2d17150c1fe448b60aab7a39b7e5d9b20ad8befbdR1-R80) [[2]](diffhunk://#diff-df2f1c7820554ab13ff3b3efbe4e987f87c6872f933715e3b2b1b111e23b6234L203-R226)

* Updated `SimulationOptionsFrame` to use `SimulationTableModel` for the simulation list, streamlining the process of populating and updating the table based on simulation events.

**Listener pattern and data model enhancements:**

* Added a simple `Listener` interface and integrated listener management into `SimulationData`, enabling UI components to react to changes in simulation data. Methods for adding listeners and notifying them (`addListener`, `notifyListeners`) were introduced. [[1]](diffhunk://#diff-f67bbb3f862b6430816d62b064ba2d5dd782bc2295720b2fd75968abf48d98c2R1-R5) [[2]](diffhunk://#diff-71baf39957a30ff906733888164c5cb88ecd43ac1d9ade0505d309c1b505fc19R39-R40) [[3]](diffhunk://#diff-71baf39957a30ff906733888164c5cb88ecd43ac1d9ade0505d309c1b505fc19R306-R319)

* `SimulationData` now stores a reference to the wind model and exposes it via a getter, supporting the new export functionality and future extensibility. [[1]](diffhunk://#diff-71baf39957a30ff906733888164c5cb88ecd43ac1d9ade0505d309c1b505fc19R39-R40) [[2]](diffhunk://#diff-71baf39957a30ff906733888164c5cb88ecd43ac1d9ade0505d309c1b505fc19L54-R56)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/waterloo-rocketry/or-monte-carlo/29)
<!-- Reviewable:end -->
